### PR TITLE
feat: apply brand palette and logo across pages

### DIFF
--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -1,0 +1,29 @@
+# Customizing Landing Pages
+
+This project uses plain HTML/CSS. You can tailor text, layout, and media by editing files directly.
+
+## Editing text and content
+- Open the HTML file for the page (e.g. `index.html`, `essencial.html`).
+- Replace the text between tags such as `<h1>`, `<p>` or list items with your own copy.
+
+## Adjusting dimensions
+- Common sizes are controlled by CSS variables in `css/styles.css`:
+  - `--container-max-width` – maximum width of page content.
+  - `--section-padding` – top and bottom padding for sections.
+- Change these values to increase or decrease the overall width or spacing.
+
+## Adding images
+1. Place image files in the `assets/` folder.
+2. Reference them in HTML: `<!-- example -->\n<img src="assets/my-photo.jpg" alt="descricao">`.
+
+## Adding videos
+1. Upload video files to the `assets/` folder (e.g. `intro.mp4`).
+2. Embed them in HTML using the `<video>` tag:
+   ```html
+   <video controls width="320">
+     <source src="assets/intro.mp4" type="video/mp4" />
+     Seu navegador não suporta vídeo.
+   </video>
+   ```
+
+After saving changes, reload the page in your browser to see the updates.

--- a/assets/icon-intregatec.svg
+++ b/assets/icon-intregatec.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="32" r="30" fill="#00b63e"/>
+  <text x="28" y="46" font-family="Arial, sans-serif" font-size="40" fill="#ffffff">i</text>
+</svg>

--- a/assets/logo-intregatec.svg
+++ b/assets/logo-intregatec.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 40">
+  <text x="0" y="30" font-family="Arial, sans-serif" font-size="32" fill="#00b63e">INTREGATEC</text>
+</svg>

--- a/conforto.html
+++ b/conforto.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Plano Recarga Conforto • Intregatec</title>
 <meta name="description" content="280 ml/mês (CMYK) com atendimento no local. Conveniência total e impressora sempre pronta.">
-<link rel="stylesheet" href="css/styles.css">
+<link rel="stylesheet" href="css/styles.css"><link rel="icon" href="assets/icon-intregatec.svg">
 <!-- GA4 (opcional) -->
 <!-- <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXX"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)};gtag('js',new Date());gtag('config','G-XXXX');</script> -->

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,0 +1,143 @@
+:root {
+  --color-dark: #001b2f;
+  --color-light: #ffffff;
+  --color-primary: #00b63e;
+  --color-black: #000000;
+  /* layout dimensions */
+  --container-max-width: 1100px;
+  --section-padding: 40px;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background: var(--color-light);
+  color: var(--color-black);
+}
+
+a { text-decoration: none; color: inherit; }
+
+.container {
+  width: 90%;
+  max-width: var(--container-max-width);
+  margin: 0 auto;
+}
+
+header.hero {
+  background: var(--color-dark);
+  color: var(--color-light);
+  padding: 32px 0;
+}
+
+.nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+}
+
+.logo img {
+  height: 40px;
+  vertical-align: middle;
+}
+.logo span {
+  color: var(--color-light);
+  margin-left: 8px;
+  font-weight: bold;
+}
+
+.grid {
+  display: grid;
+  gap: 20px;
+}
+.grid-2 {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.card {
+  background: rgba(0, 27, 47, 0.05);
+  padding: 16px;
+  border-radius: 8px;
+}
+
+.btn {
+  display: inline-block;
+  padding: 8px 16px;
+  border-radius: 4px;
+  font-weight: 600;
+}
+.btn-primary {
+  background: var(--color-primary);
+  color: var(--color-light);
+}
+.btn-ghost {
+  border: 2px solid var(--color-primary);
+  color: var(--color-primary);
+}
+
+.section {
+  padding: var(--section-padding) 0;
+}
+.section.alt {
+  background: rgba(0, 27, 47, 0.05);
+}
+
+.cards {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+.plan {
+  background: var(--color-light);
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 8px;
+  padding: 16px;
+  text-align: center;
+}
+.badge {
+  display: inline-block;
+  background: var(--color-primary);
+  color: var(--color-light);
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  margin-bottom: 8px;
+}
+.price {
+  font-size: 24px;
+  font-weight: bold;
+  margin-top: 12px;
+}
+
+.benefits {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+.benefit {
+  background: rgba(0, 27, 47, 0.05);
+  padding: 16px;
+  border-radius: 8px;
+}
+
+.kpis {
+  display: flex;
+  justify-content: space-around;
+}
+.kpi {
+  text-align: center;
+}
+
+.cta-final {
+  background: var(--color-dark);
+  color: var(--color-light);
+  padding: 40px 0;
+}
+footer {
+  background: var(--color-dark);
+  color: var(--color-light);
+  text-align: center;
+  padding: 16px 0;
+  font-size: 14px;
+}

--- a/empresarial.html
+++ b/empresarial.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Plano Recarga Empresarial • Intregatec</title>
 <meta name="description" content="Para quem não pode parar: recarga no local + preventiva + prioridade em fila. Escala para múltiplas impressoras.">
-<link rel="stylesheet" href="css/styles.css">
+<link rel="stylesheet" href="css/styles.css"><link rel="icon" href="assets/icon-intregatec.svg">
 <!-- GA4 (opcional) -->
 <!-- <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXX"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)};gtag('js',new Date());gtag('config','G-XXXX');</script> -->

--- a/essencial.html
+++ b/essencial.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Plano Recarga Essencial • Intregatec</title>
 <meta name="description" content="280 ml/mês (70 ml de Ciano, Preto, Magenta e Amarelo). Retirada na assistência. Qualidade Profeel e economia real.">
-<link rel="stylesheet" href="css/styles.css">
+<link rel="stylesheet" href="css/styles.css"><link rel="icon" href="assets/icon-intregatec.svg">
 <!-- GA4 (opcional) -->
 <!-- <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXX"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)};gtag('js',new Date());gtag('config','G-XXXX');</script> -->

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Intregatec • Planos de Recarga Epson (EcoTank)</title>
 <meta name="description" content="Assinaturas de recarga de tinta com benefícios progressivos. Escolha seu plano e assine online via InfinitePay.">
-<link rel="stylesheet" href="css/styles.css">
+<link rel="stylesheet" href="css/styles.css"><link rel="icon" href="assets/icon-intregatec.svg">
 <!-- GA4 (opcional) -->
 <!-- <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXX"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)};gtag('js',new Date());gtag('config','G-XXXX');</script> -->

--- a/performance.html
+++ b/performance.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Plano Recarga Performance • Intregatec</title>
 <meta name="description" content="Tudo incluído no seu endereço: recarga mensal e preventiva trimestral. Mais rapidez para chegar aos maiores descontos.">
-<link rel="stylesheet" href="css/styles.css">
+<link rel="stylesheet" href="css/styles.css"><link rel="icon" href="assets/icon-intregatec.svg">
 <!-- GA4 (opcional) -->
 <!-- <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXX"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)};gtag('js',new Date());gtag('config','G-XXXX');</script> -->

--- a/protecao.html
+++ b/protecao.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Plano Recarga Proteção • Intregatec</title>
 <meta name="description" content="Recarga mensal + manutenção preventiva a cada 3 meses. Tranquilidade e custo total menor no médio prazo.">
-<link rel="stylesheet" href="css/styles.css">
+<link rel="stylesheet" href="css/styles.css"><link rel="icon" href="assets/icon-intregatec.svg">
 <!-- GA4 (opcional) -->
 <!-- <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXX"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)};gtag('js',new Date());gtag('config','G-XXXX');</script> -->


### PR DESCRIPTION
## Summary
- add brand styles with dark blue, green, white and black palette
- include Intregatec logo and favicon assets
- reference new branding on all service pages
- document how to edit page content, dimensions and media

## Testing
- `tidy -q index.html` *(fails: command not found)*
- `rg -n -- '--container-max-width|--section-padding' css/styles.css`


------
https://chatgpt.com/codex/tasks/task_e_68b74454d7448331b86f44f3713561ee